### PR TITLE
Distinct messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 
 ## Build status:
 [![CircleCI](https://circleci.com/gh/SoLaDi/gebot-app.svg?style=shield)](https://circleci.com/gh/SoLaDi/gebot-app)
+
+## Local development
+
+### config
+
+Take example config and set values according to your needs.
+
+    mv .env.example .env
+
+
+### startup
+
+    rails tailwindcss:build
+    rails server

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :info, :error, :warning
+
   def index
     if Rails.env.development?
       redirect_to membership_path(id: ENV['EXAMPLE_USER_MAGIC_TOKEN'])

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,7 +1,5 @@
 class MembershipsController < ApplicationController
   def show
-    flash[:notice] = nil
-    flash[:error] = nil
     magic_token = params[:id]
     Rails.logger.info "Going to check magic token: #{magic_token}"
     response = conn.get('/api/magic_link/login', { token: magic_token }, headers)
@@ -73,13 +71,11 @@ class MembershipsController < ApplicationController
 
       if response.status == 202
         Rails.logger.info("Bid placed successfully")
-        flash[:notice] = 'Dein Mitgliedsbeitrag wurde erfolgreich gespeichert'
         MemberMailer.with(name: update_params[:name], email: update_params[:email], bid: update_params[:amount].to_f, membership_id: update_params[:id]).notify_bid.deliver_later
         redirect_to membership_path(params[:id])
       else
         Rails.logger.error("Failed to place bid: #{response.inspect}")
-        flash[:error] = JSON.parse(response.body)
-        render :show
+        redirect_to membership_path(params[:id]), error: JSON.parse(response.body)
       end
     end
   end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -84,7 +84,7 @@ class MembershipsController < ApplicationController
       @membership = Membership.new({
                                      id: update_params[:id].to_i,
                                      name: update_params[:name],
-                                     name: update_params[:email],
+                                     email: update_params[:email],
                                      amount: update_params[:amount].to_f,
                                      shares: update_params[:shares].to_i,
                                    })

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -36,7 +36,7 @@ class MembershipsController < ApplicationController
         last_bid = bids.filter { |bid| bid[:start_date] == "2021-04-01" }.first
         # we take last years number of shares or 1 if no old bid is found
         shares = last_bid ? last_bid[:shares] : 1
-        default_amount = 95.0
+        default_amount = 98.0
 
         @membership = Membership.new(
           {

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,10 +1,12 @@
 class Membership
   include ActiveModel::API
 
+  # can be [:open_for_bid, :bid_placed_by_other_member, :bid_placed_by_self]
+  attr_accessor :status, :string
+
   attr_accessor :id, :integer
   attr_accessor :name, :string
   attr_accessor :email, :string
   attr_accessor :amount, :float
   attr_accessor :shares, :int
-  attr_accessor :has_current_bid, :bool
 end

--- a/app/views/memberships/show.html.erb
+++ b/app/views/memberships/show.html.erb
@@ -35,17 +35,30 @@
   Hallo <%= @membership.name %>,
 </h3>
 
-<% if @membership.has_current_bid %>
+<% case @membership.status %>
+<% when :bid_placed_by_other_member %>
   <div id="current_bid">
-    <p>Es wurde bereits ein Gebot abgegeben für deine Mitgliedschaft mit folgenden Daten:</p>
-    <p>Mitgliedschaftsnummer: <%= @membership.id %></p>
-    <p>Betrag: <%= @membership.amount %></p>
+    <p>Ein anderes Mitglied hat bereits ein Gebot abgegeben für deine Mitgliedschaft mit der Nummer S<%= @membership.id %>:</p>
+    <p>Betrag: <%= number_to_currency(@membership.amount) %></p>
     <p>Anteile: <%= @membership.shares %></p>
   </div>
-
+<% when :bid_placed_by_self %>
+  <div id="current_bid">
+    <p>Wir haben dein Gebot gespeichert mit folgenden Daten:</p>
+    <p>Mitgliedschaftsnummer: S<%= @membership.id %></p>
+    <p>Betrag: <%= number_to_currency(@membership.amount) %></p>
+    <p>Anteile: <%= @membership.shares %></p>
+  </div>
 <% else %>
   <div id="new_bid_form">
-    du hast momentan <%= @membership.shares %> <%= @membership.shares > 1 ? 'Anteile' : 'Anteil' %>.
+    <% if @membership.shares > 1 %>
+      Deine Mitgliedschaft mit der Nummer S<%= @membership.id %> bezieht momentan <%= @membership.shares %> Anteile.<br/>
+      Dein Gebot bezieht sich auf einen Anteil. Daraus folgt:<br/>
+      <br/>
+      Monatlich zu zahlender Betrag = Dein Gebot mal Anzahl der Anteile.
+    <% else %>
+      Deine Mitgliedschaft hat die Nummer S<%= @membership.id %>.
+    <% end %>
     <br/>
     <br/>
     <%= form_for @membership, url: { :action => "edit" }, method: :put do |form| %>
@@ -53,10 +66,10 @@
       <%= form.hidden_field :name %>
       <%= form.hidden_field :email %>
       <%= form.hidden_field :shares %>
-      <%= form.label :amount, "Dein neuer Mitgliedsbeitrag für 2022:" %>
+      <%= form.label :amount, "Bitte gib dein Gebot für 2022 ein:" %>
       <div class="mt-1 flex flex-col sm:flex-row">
         <div class="relative rounded-md shadow-sm grow sm:mr-1">
-          <%= form.number_field :amount, in: 80.0..120.0, step: 0.1, class: "focus:ring-apfeltraum focus:border-apfeltraum block w-full pr-7 sm:text-sm border-apfeltraum rounded-md" %>
+          <%= form.number_field :amount, in: 50.0..200.0, step: 0.01, class: "focus:ring-apfeltraum focus:border-apfeltraum block w-full pr-7 sm:text-sm border-apfeltraum rounded-md" %>
           <div class="absolute inset-y-0 right-2 pl-3 flex items-center pointer-events-none">
             <span class="text-gray-500 sm:text-sm">€</span>
           </div>


### PR DESCRIPTION
Introduce a status field that reflects the current status of the bid. 
- If there is none, it's open for a bid.
- If a bit was already placed it was either 
-- done by the person logged in
-- by another member of the membership

This change shows distinct error messages for each of these cases.
